### PR TITLE
build: make logger and its man page optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,10 @@ AC_ARG_WITH(systemd,
      [AS_HELP_STRING([--with-systemd=DIR], [Directory for systemd service files])],,
      [with_systemd=auto])
 
+AC_ARG_WITH(logger,
+     AS_HELP_STRING([--without-logger], [Do not build/install logger binary and man page, default: enabled]),
+     [logger=$withval], [logger='yes'])
+
 AS_IF([test "x$klogd" != "xno"],
         with_klogd="yes"
 	AC_DEFINE(KLOGD, 1, [Build with klogd, default: built-in /dev/kmsg support in syslogd]),
@@ -96,6 +100,12 @@ AS_IF([test "x$with_systemd" = "xyes" -o "x$with_systemd" = "xauto"], [
 AS_IF([test "x$with_systemd" != "xno"],
      [AC_SUBST([systemddir], [$with_systemd])])
 AM_CONDITIONAL([HAVE_SYSTEMD], [test "x$with_systemd" != "xno"])
+
+AS_IF([test "x$logger" != "xno"], [
+	with_logger="yes"
+	AC_DEFINE(LOGGER, 1, [Build with logger])],
+	with_logger="no")
+AM_CONDITIONAL([ENABLE_LOGGER], [test "x$with_logger" != "xno"])
 
 # Expand $sbindir early, into $SBINDIR, for systemd unit file
 # NOTE: This does *not* take prefix/exec_prefix override at "make

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,8 +1,12 @@
-dist_man1_MANS  = logger.1
+dist_man1_MANS  =
 dist_man3_MANS	= syslogp.3
 dist_man5_MANS	= syslog.conf.5
 dist_man8_MANS	= syslogd.8
 
 if ENABLE_KLOGD
 dist_man8_MANS += klogd.8
+endif
+
+if ENABLE_LOGGER
+dist_man1_MANS += logger.1
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,13 +16,17 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-bin_PROGRAMS          = logger
+bin_PROGRAMS          =
 sbin_PROGRAMS         = syslogd
 lib_LTLIBRARIES       = libsyslog.la
 noinst_LTLIBRARIES    = libcompat.la
 
 if ENABLE_KLOGD
 sbin_PROGRAMS        += klogd
+endif
+
+if ENABLE_LOGGER
+bin_PROGRAMS	     += logger
 endif
 
 AM_CFLAGS             = -W -Wall -Wextra
@@ -39,10 +43,12 @@ klogd_CPPFLAGS        = $(AM_CPPFLAGS)
 klogd_LDADD           = $(LIBS) $(LIBOBJS)
 klogd_LDADD          += libsyslog.la
 
+if ENABLE_LOGGER
 logger_SOURCES        = logger.c syslog.h
 logger_CPPFLAGS       = $(AM_CPPFLAGS) -D_XOPEN_SOURCE=600
 logger_LDADD          = $(LIBS) $(LIBOBJS)
 logger_LDADD         += libsyslog.la
+endif
 
 # Convenience library for libsyslog instead of linking with $(LTLIBOBJS),
 # which would pull in pidfile() and other (strong) symbols as well.


### PR DESCRIPTION
There are other packages that provide a logger program like `util-linux`
We should respekt that

I've tried to make this change as non-intrusive as possible. Build and installation of logger is still enabled by default.