### PR TITLE
Fix parallel build issues

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -51,7 +51,3 @@ release: distcheck
 
 # Workaround for systemd unit file duing distcheck
 DISTCHECK_CONFIGURE_FLAGS = --with-systemd=$$dc_install_base/$(systemd)
-
-# Disable parallel build in top Makefile, we might otherwise get a very
-# bizarre build problem with strlcpy.o in libcompat and for syslogd.
-.NOTPARALLEL:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,7 +28,12 @@
 bin_PROGRAMS          =
 sbin_PROGRAMS         = syslogd
 lib_LTLIBRARIES       = libsyslog.la
-noinst_LTLIBRARIES    = libcompat.la
+
+# Convenience library for libsyslog instead of linking with $(LTLIBOBJS),
+# which would pull in pidfile() and other (strong) symbols as well.
+noinst_LTLIBRARIES    = libstrlcpy.la libstrlcat.la
+libstrlcat_la_SOURCES  =
+libstrlcpy_la_SOURCES  =
 
 if ENABLE_LOGGER
 bin_PROGRAMS	     += logger
@@ -48,10 +53,6 @@ logger_CPPFLAGS       = $(AM_CPPFLAGS) -D_XOPEN_SOURCE=600
 logger_LDADD          = $(LIBS) $(LIBOBJS)
 logger_LDADD         += libsyslog.la
 
-# Convenience library for libsyslog instead of linking with $(LTLIBOBJS),
-# which would pull in pidfile() and other (strong) symbols as well.
-libcompat_la_SOURCES  = ../lib/strlcpy.c ../lib/strlcat.c
-
 pkgconfigdir          = $(libdir)/pkgconfig
 pkgincludedir         = $(includedir)/syslog
 pkgconfig_DATA        = libsyslog.pc
@@ -59,4 +60,4 @@ pkginclude_HEADERS    = syslog.h
 libsyslog_la_SOURCES  = syslog.c syslog.h compat.h
 libsyslog_la_CPPFLAGS = $(AM_CPPFLAGS) -D_XOPEN_SOURCE=600
 libsyslog_la_LDFLAGS  = $(AM_LDFLAGS) -version-info 0:0:0
-libsyslog_la_LIBADD   = libcompat.la
+libsyslog_la_LIBADD   = libstrlcpy.la libstrlcat.la


### PR DESCRIPTION
The following line causes strlcat.o and strlcpy.o generate twice:

libcompat_la_SOURCES  = ../lib/strlcpy.c ../lib/strlcat.c

Which causes parallel build issues like:
https://bugs.gentoo.org/701894

The log shows that they have been generated twice, but should only be once, the
extra one is for libstrlcat.lo, this patch fixes the problem, now the log only
shows once for each of them.

And also restore the parallel build.

Signed-off-by: Robert Yang <liezhi.yang@windriver.com>