### PR TITLE
New Parameter to Control Listen Interface

### DIFF
--- a/docs/README.1st
+++ b/docs/README.1st
@@ -6,9 +6,9 @@ to the one in former releases.  Please review the following important
 differences:
 
 * By default the syslog daemon doesn't accept any message from the
-  syslog/udp port. To enable this add "-r" to the command-line
-  arguments. You _have to_ add this on every host that should run as a
-  centralized network log server.
+  syslog/udp port. To enable this add "-r" or "-R ADDR" to the 
+  command-line arguments. You _have to_ add this on every host that 
+  should run as a centralized network log server.
 
   You also should take a look at other new command-line arguments:
   "-l" and "-s".

--- a/man/sysklogd.8
+++ b/man/sysklogd.8
@@ -33,6 +33,9 @@ sysklogd \- Linux system logging utilities.
 .IB socket 
 ]
 .RB [ " \-r " ]
+.RB [ " \-R "
+.I address
+]
 .RB [ " \-s "
 .I domainlist
 ]
@@ -193,6 +196,11 @@ The default is to not receive any messages from the network.
 This option is introduced in version 1.3 of the sysklogd
 package.  Please note that the default behavior is the opposite of
 how older versions behave, so you might have to turn this on.
+.TP
+.BI "\-R " "address"
+This option behaves the same as the '-r' option except that instead
+of listening on all interfaces, the process will only bind to the
+given address.
 .TP
 .BI "\-s " "domainlist"
 Specify a domainname that should be stripped off before


### PR DESCRIPTION
Currently when providing the "-r" argument to syslogd, the daemon binds to the "wildcard" interface address (eg, 0.0.0.0 for IPv4). This may be undesirable for some users as they may want to control which interface syslogd binds to. This change adds the "-R ADDR" parameter which accepts a specific IP address to bind.