### PR TITLE
Keep mode

### DIFF
--- a/man/syslog.conf.5
+++ b/man/syslog.conf.5
@@ -105,6 +105,17 @@ cron or a separate log rotate daemon.
 Comments, lines starting with a hash mark ('#'), and empty lines are
 ignored.  If an error occurs during parsing the whole line is ignored.
 .Pp
+The special keyword
+.Em notify
+specifies the path to an executable program which will get called
+whenever a log file has been rotated, with the name of the file, less
+its rotation suffix
+.Ql .0 ,
+as an argument.
+For example:
+.Ql notify /sbin/on-log-rotate.sh .
+Any number of notifiers may be installed.
+.Pp
 A special
 .Em include
 keyword can be used to include all files with names ending in '.conf'

--- a/man/syslogd.8
+++ b/man/syslogd.8
@@ -483,6 +483,10 @@ SIGTERM.
 .It USR1
 In debug mode this switches debugging on/off.  In normal operation
 it is ignored.
+.It USR2
+.Nm
+will rotate all files for which rotation is configured when receiving
+this signal.
 .El
 .Pp
 For convenience the PID is by default stored in

--- a/src/syslogd.h
+++ b/src/syslogd.h
@@ -305,6 +305,14 @@ struct filed {
 	int	 f_rotatesz;
 };
 
+/*
+ * Log rotation notifiers
+ */
+struct notifier {
+	SIMPLEQ_ENTRY(notifier)	 n_link;
+	char			*n_program;
+};
+
 void flog(int pri, char *fmt, ...);
 
 #endif /* SYSKLOGD_SYSLOGD_H_ */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,5 @@
 EXTRA_DIST       = lib.sh opts.sh
-EXTRA_DIST      += api.sh local.sh unicode.sh remote.sh fwd.sh mark.sh
+EXTRA_DIST      += api.sh local.sh unicode.sh remote.sh fwd.sh mark.sh notify.sh
 CLEANFILES       = *~ *.trs *.log
 TEST_EXTENSIONS  = .sh
 TESTS_ENVIRONMENT= unshare -mrun
@@ -17,5 +17,6 @@ TESTS           += remote.sh
 TESTS           += api.sh
 TESTS           += fwd.sh
 TESTS           += mark.sh
+TESTS           += notify.sh
 
 programs: $(check_PROGRAMS)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,6 @@
 EXTRA_DIST       = lib.sh opts.sh
-EXTRA_DIST      += api.sh local.sh unicode.sh remote.sh fwd.sh mark.sh notify.sh
+EXTRA_DIST      += api.sh local.sh unicode.sh remote.sh fwd.sh mark.sh \
+			notify.sh rotate_all.sh
 CLEANFILES       = *~ *.trs *.log
 TEST_EXTENSIONS  = .sh
 TESTS_ENVIRONMENT= unshare -mrun
@@ -18,5 +19,6 @@ TESTS           += api.sh
 TESTS           += fwd.sh
 TESTS           += mark.sh
 TESTS           += notify.sh
+TESTS           += rotate_all.sh
 
 programs: $(check_PROGRAMS)

--- a/test/notify.sh
+++ b/test/notify.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -x
+
+if [ x"${srcdir}" = x ]; then
+    srcdir=.
+fi
+. ${srcdir}/lib.sh
+
+NOT1=${DIR}/${NM}-1.sh
+NOT1STAMP=${DIR}/${NM}-1.stamp
+NOT2=${DIR}/${NM}-2.sh
+NOT2STAMP=${DIR}/${NM}-2.stamp
+
+printf '#!/bin/sh -\necho script 1: $* > '${NOT1STAMP}'\n' > ${NOT1}
+printf '#!/bin/sh -\necho script 2: $* > '${NOT2STAMP}'\n' > ${NOT2}
+chmod 0755 ${NOT1} ${NOT2}
+
+cat <<EOF > ${CONF}
+notify ${NOT1}
+# Match all log messages, store in RC5424 format and rotate every 1 KiB
+*.*       -${LOG}    ;rotate=1k:2,RFC5424
+notify ${NOT2}
+EOF
+
+../src/syslogd -m1 -b :${PORT2} -d -sF -f ${CONF} -p ${SOCK2} -p ${ALTSOCK} -P ${PID2} >${LOG2} &
+sleep 3
+cat ${PID2} >> "$DIR/PIDs"
+
+if grep 'notify '${NOT1} ${LOG2} && grep 'notify '${NOT2} ${LOG2}; then
+	:
+else
+	exit $?
+fi
+
+if [ -x ../src/logger ]; then
+	:
+else
+	exit 0
+fi
+
+kill -USR1 `cat ${PID2}`
+
+MSG=01234567890123456789012345678901234567890123456789
+MSG=$MSG$MSG$MSG$MSG$MSG$MSG$MSG$MSG$MSG$MSG
+../src/logger -u ${SOCK2} ${MSG}
+../src/logger -u ${SOCK2} 1${MSG}
+../src/logger -u ${SOCK2} 2${MSG}
+
+kill -9 `cat ${PID2}`
+
+sleep 1 # XXX synchronization of async process?
+if [ -f ${LOG}.0 ] &&
+		grep 'script 1' ${NOT1STAMP} &&
+		grep 'script 2' ${NOT2STAMP}; then
+	:
+else
+	exit 1
+fi

--- a/test/notify.sh
+++ b/test/notify.sh
@@ -6,6 +6,8 @@ if [ x"${srcdir}" = x ]; then
 fi
 . ${srcdir}/lib.sh
 
+[ -x ../src/logger ] || SKIP 'logger missing'
+
 NOT1=${DIR}/${NM}-1.sh
 NOT1STAMP=${DIR}/${NM}-1.stamp
 NOT2=${DIR}/${NM}-2.sh
@@ -15,44 +17,25 @@ printf '#!/bin/sh -\necho script 1: $* > '${NOT1STAMP}'\n' > ${NOT1}
 printf '#!/bin/sh -\necho script 2: $* > '${NOT2STAMP}'\n' > ${NOT2}
 chmod 0755 ${NOT1} ${NOT2}
 
-cat <<EOF > ${CONF}
-notify ${NOT1}
+cat <<EOF > ${CONFD}/notifier.conf
+notify      ${NOT1}
 # Match all log messages, store in RC5424 format and rotate every 1 KiB
 *.*       -${LOG}    ;rotate=1k:2,RFC5424
 notify ${NOT2}
 EOF
 
-../src/syslogd -m1 -b :${PORT2} -d -sF -f ${CONF} -p ${SOCK2} -p ${ALTSOCK} -P ${PID2} >${LOG2} &
-sleep 3
-cat ${PID2} >> "$DIR/PIDs"
-
-if grep 'notify '${NOT1} ${LOG2} && grep 'notify '${NOT2} ${LOG2}; then
-	:
-else
-	exit $?
-fi
-
-if [ -x ../src/logger ]; then
-	:
-else
-	exit 0
-fi
-
-kill -USR1 `cat ${PID2}`
+setup
 
 MSG=01234567890123456789012345678901234567890123456789
 MSG=$MSG$MSG$MSG$MSG$MSG$MSG$MSG$MSG$MSG$MSG
-../src/logger -u ${SOCK2} ${MSG}
-../src/logger -u ${SOCK2} 1${MSG}
-../src/logger -u ${SOCK2} 2${MSG}
+../src/logger -u ${SOCK} ${MSG}
+../src/logger -u ${SOCK} 1${MSG}
+../src/logger -u ${SOCK} 2${MSG}
 
-kill -9 `cat ${PID2}`
-
-sleep 1 # XXX synchronization of async process?
 if [ -f ${LOG}.0 ] &&
 		grep 'script 1' ${NOT1STAMP} &&
 		grep 'script 2' ${NOT2STAMP}; then
-	:
+	OK
 else
-	exit 1
+	FAIL 'Notifier did not run.'
 fi

--- a/test/rotate_all.sh
+++ b/test/rotate_all.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+set -x
+
+if [ x"${srcdir}" = x ]; then
+    srcdir=.
+fi
+. ${srcdir}/lib.sh
+
+NOT1=${DIR}/${NM}-1.sh
+echo $NOT1 > /tmp/Xxxxx
+NOT1STAMP=${DIR}/${NM}-1.stamp
+NOT2=${DIR}/${NM}-2.sh
+NOT2STAMP=${DIR}/${NM}-2.stamp
+
+printf '#!/bin/sh -\necho script 1: $* > '${NOT1STAMP}'\n' > ${NOT1}
+chmod 0755 ${NOT1}
+
+cat <<EOF > ${CONF}
+notify ${NOT1}
+*.*       -${LOG}    ;rotate=10k:2,RFC5424
+*.*       -${LOG}X   ;rotate=10k:2,RFC5424
+EOF
+
+../src/syslogd -m1 -b :${PORT2} -d -sF -f ${CONF} -p ${SOCK2} -p ${ALTSOCK} -P ${PID2} >${LOG2} &
+sleep 3
+cat ${PID2} >> "$DIR/PIDs"
+
+sleep 1
+
+if grep 'notify '${NOT1} ${LOG2}; then
+	:
+else
+	exit $?
+fi
+
+if [ -x ../src/logger ]; then
+	:
+else
+	exit 0
+fi
+
+kill -USR1 `cat ${PID2}`
+
+../src/logger -u ${SOCK2} notrotall-1
+kill -USR2 `cat ${PID2}`
+sleep 1 # XXX async process sync?
+if [ -f ${LOG}.0 ] && [ -f ${LOG}X.0 ] &&
+		grep notrotall-1 ${LOG}.0 &&
+		grep notrotall-1 ${LOG}X.0; then
+	:
+else
+	exit 1
+fi
+
+rm -f ${NOT1STAMP}
+../src/logger -u ${SOCK2} notrotall-2
+kill -USR2 `cat ${PID2}`
+sleep 1 # XXX async process sync?
+if [ -f ${LOG}.0 ] && [ -f ${LOG}X.0 ] &&
+		[ -f ${LOG}.1.gz ] && [ -f ${LOG}X.1.gz ] &&
+		grep notrotall-2 ${LOG}.0 &&
+		grep notrotall-2 ${LOG}X.0 &&
+		zgrep notrotall-1 ${LOG}.1.gz &&
+		zgrep notrotall-1 ${LOG}X.1.gz; then
+	:
+else
+	exit 1
+fi
+
+rm -f ${NOT1STAMP}
+../src/logger -u ${SOCK2} notrotall-3
+kill -USR2 `cat ${PID2}`
+sleep 1 # XXX async process sync?
+if [ -f ${LOG}.0 ] && [ -f ${LOG}X.0 ] &&
+		[ -f ${LOG}.1.gz ] && [ -f ${LOG}X.1.gz ] &&
+		[ -f ${LOG}.2.gz ] && [ -f ${LOG}X.2.gz ] &&
+		grep notrotall-3 ${LOG}.0 &&
+		grep notrotall-3 ${LOG}X.0 &&
+		zgrep notrotall-2 ${LOG}.1.gz &&
+		zgrep notrotall-2 ${LOG}X.1.gz &&
+		zgrep notrotall-1 ${LOG}.2.gz &&
+		zgrep notrotall-1 ${LOG}X.2.gz; then
+	:
+else
+	exit 1
+fi
+
+kill -9 `cat ${PID2}`
+
+sleep 1 # XXX synchronization of async process?
+if [ -f ${LOG}.0 ] && grep 'script 1' ${NOT1STAMP}; then
+	:
+else
+	exit 1
+fi

--- a/test/rotate_all.sh
+++ b/test/rotate_all.sh
@@ -6,56 +6,49 @@ if [ x"${srcdir}" = x ]; then
 fi
 . ${srcdir}/lib.sh
 
+[ -x ../src/logger ] || SKIP 'logger missing'
+command -v zgrep >/dev/null 2>&1 || SKIP 'zgrep(1) missing'
+
 NOT1=${DIR}/${NM}-1.sh
-echo $NOT1 > /tmp/Xxxxx
 NOT1STAMP=${DIR}/${NM}-1.stamp
 NOT2=${DIR}/${NM}-2.sh
 NOT2STAMP=${DIR}/${NM}-2.stamp
 
-printf '#!/bin/sh -\necho script 1: $* > '${NOT1STAMP}'\n' > ${NOT1}
+printf '#!/bin/sh -\necho script 1: $* >> '${NOT1STAMP}'\n' > ${NOT1}
 chmod 0755 ${NOT1}
 
-cat <<EOF > ${CONF}
+cat <<EOF > ${CONFD}/rotate_all.conf
 notify ${NOT1}
 *.*       -${LOG}    ;rotate=10k:2,RFC5424
 *.*       -${LOG}X   ;rotate=10k:2,RFC5424
 EOF
 
-../src/syslogd -m1 -b :${PORT2} -d -sF -f ${CONF} -p ${SOCK2} -p ${ALTSOCK} -P ${PID2} >${LOG2} &
+setup
+
+rm -f ${NOT1STAMP}
+../src/logger -u ${SOCK} notrotall-1
+
+kill -USR2 `cat ${PID}`
 sleep 3
-cat ${PID2} >> "$DIR/PIDs"
-
-sleep 1
-
-if grep 'notify '${NOT1} ${LOG2}; then
-	:
-else
-	exit $?
-fi
-
-if [ -x ../src/logger ]; then
-	:
-else
-	exit 0
-fi
-
-kill -USR1 `cat ${PID2}`
-
-../src/logger -u ${SOCK2} notrotall-1
-kill -USR2 `cat ${PID2}`
-sleep 1 # XXX async process sync?
 if [ -f ${LOG}.0 ] && [ -f ${LOG}X.0 ] &&
 		grep notrotall-1 ${LOG}.0 &&
 		grep notrotall-1 ${LOG}X.0; then
 	:
 else
-	exit 1
+	FAIL 'Missing log entries, I.'
+fi
+if [ -f ${NOT1STAMP} ] && grep 'script 1' ${NOT1STAMP} &&
+		grep ${LOG} ${NOT1STAMP} && grep ${LOG}X ${NOT1STAMP}; then
+	:
+else
+	FAIL 'Notifier did not run, I.'
 fi
 
 rm -f ${NOT1STAMP}
-../src/logger -u ${SOCK2} notrotall-2
-kill -USR2 `cat ${PID2}`
-sleep 1 # XXX async process sync?
+../src/logger -u ${SOCK} notrotall-2
+
+kill -USR2 `cat ${PID}`
+sleep 3
 if [ -f ${LOG}.0 ] && [ -f ${LOG}X.0 ] &&
 		[ -f ${LOG}.1.gz ] && [ -f ${LOG}X.1.gz ] &&
 		grep notrotall-2 ${LOG}.0 &&
@@ -64,13 +57,21 @@ if [ -f ${LOG}.0 ] && [ -f ${LOG}X.0 ] &&
 		zgrep notrotall-1 ${LOG}X.1.gz; then
 	:
 else
-	exit 1
+	FAIL 'Missing log entries, II.'
+fi
+if [ -f ${NOT1STAMP} ] && grep 'script 1' ${NOT1STAMP} &&
+		grep ${LOG} ${NOT1STAMP} && grep ${LOG}X ${NOT1STAMP}; then
+	:
+else
+	FAIL 'Notifier did not run, II.'
 fi
 
+cp $NOT1STAMP /tmp/
 rm -f ${NOT1STAMP}
-../src/logger -u ${SOCK2} notrotall-3
-kill -USR2 `cat ${PID2}`
-sleep 1 # XXX async process sync?
+../src/logger -u ${SOCK} notrotall-3
+
+kill -USR2 `cat ${PID}`
+sleep 3
 if [ -f ${LOG}.0 ] && [ -f ${LOG}X.0 ] &&
 		[ -f ${LOG}.1.gz ] && [ -f ${LOG}X.1.gz ] &&
 		[ -f ${LOG}.2.gz ] && [ -f ${LOG}X.2.gz ] &&
@@ -82,14 +83,13 @@ if [ -f ${LOG}.0 ] && [ -f ${LOG}X.0 ] &&
 		zgrep notrotall-1 ${LOG}X.2.gz; then
 	:
 else
-	exit 1
+	FAIL 'Missing log entries, III.'
 fi
-
-kill -9 `cat ${PID2}`
-
-sleep 1 # XXX synchronization of async process?
-if [ -f ${LOG}.0 ] && grep 'script 1' ${NOT1STAMP}; then
+if [ -f ${NOT1STAMP} ] && grep 'script 1' ${NOT1STAMP} &&
+		grep ${LOG} ${NOT1STAMP} && grep ${LOG}X ${NOT1STAMP}; then
 	:
 else
-	exit 1
+	FAIL 'Notifier did not run, III.'
 fi
+
+OK


### PR DESCRIPTION
Hello.
It happens that syslogd.c looses the file mode when rotating files, it always uses 0644.
(Your logger.c does not, but CRUX-Linux does not use the logger from sysklogd, it .. uses that from the util-linux package.)

So here is a patch on top of the rotate branch that simply passes the fetched stat mode to carry the mode along.