### PR TITLE
patch to prevent truncation when forwarding a message to a tty

### DIFF
--- a/src/syslogd.c
+++ b/src/syslogd.c
@@ -1857,7 +1857,7 @@ void fprintlog_write(struct filed *f, struct iovec *iov, int iovcnt, int flags)
 		f->f_time = timer_now();
 		logit("\n");
 		pushiov(iov, iovcnt, "\r\n");
-		wallmsg(f, &iov[1], iovcnt - 1);
+		wallmsg(f, &iov[0], iovcnt);
 		break;
 	} /* switch */
 


### PR DESCRIPTION
This is a patch to fprintlog_write() that eliminates a redundant skip past the PRI field of the iov when passing it to wallmsg().

Because wallmsg() assumes the PRI field is the first field present in the iov, it wrongly truncates the hostname and part or all of the message body before writing on the tty.