### PR TITLE
Prevent logfile corruption by control codes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@ Change Log
 All relevant changes to the project are documented in this file.
 
 
-[v2.4.0][] - 2022-05-29
+[v2.4.0][] - 2022-06-16
 -----------------------
 
 ### Changes
@@ -31,6 +31,11 @@ All relevant changes to the project are documented in this file.
   data to be logged -- this is a temporary fix until we have support
   for parsing the Unicode BOM, as defined in RFC5424
 - Issue #50: fix issue with wall message, by Edward K. McGuire
+- Do not corrupt logfiles when kernel messages contain control codes,
+  notably `\n`. Instead, preserve the kernel's protective C-style hex
+  encoding. For example, `\n` embedded in a message by a kernel-level
+  facility is received as `\x0a`. See:
+  <https://kernel.org/doc/Documentation/ABI/testing/dev-kmsg>
 
 
 [v2.3.0][] - 2021-11-27

--- a/src/syslogd.c
+++ b/src/syslogd.c
@@ -1428,18 +1428,8 @@ void printsys(char *msg)
 		}
 
 		q = lp;
-		while (*p != '\0' && (c = *p++) != '\n' && q < &line[MAXLINE]) {
-			/* Linux /dev/kmsg C-style hex encoding. */
-			if (c == '\\' && *p == 'x') {
-				char code[5] = "0x\0\0\0";
-
-				p++;
-				code[2] = *p++;
-				code[3] = *p++;
-				c = (int)strtol(code, NULL, 16);
-			}
+		while (*p != '\0' && (c = *p++) != '\n' && q < &line[MAXLINE])
 			*q++ = c;
-		}
 		*q = '\0';
 
 		logmsg(&buffer);


### PR DESCRIPTION
Do not corrupt logfiles when kernel messages contain control codes,
notably \n. Instead, preserve the kernel's protective C-style hex
encoding. For example, \n embedded in a message by a kernel-level
facility is received as "\x0a". Kernel-level facilities cannot be
trusted to use only syslog-safe codes in kernel messages. See:
<https://kernel.org/doc/Documentation/ABI/testing/dev-kmsg>