### PR TITLE
Fix function prototypes for `-std=c2x`

### DIFF
--- a/src/syslogd.c
+++ b/src/syslogd.c
@@ -201,15 +201,15 @@ static void rotate_file(struct filed *f, struct stat *stp_or_null);
 static void rotate_all_files(void);
 static void fprintlog_first(struct filed *f, struct buf_msg *buffer);
 static void fprintlog_successive(struct filed *f, int flags);
-void        endtty();
+void        endtty(int);
 void        wallmsg(struct filed *f, struct iovec *iov, int iovcnt);
-void        reapchild();
+void        reapchild(int);
 const char *cvtaddr(struct sockaddr_storage *f, int len);
 const char *cvthname(struct sockaddr *f, socklen_t len);
 static void forw_lookup(struct filed *f);
 void        domark(void *arg);
 void        doflush(void *arg);
-void        debug_switch();
+void        debug_switch(int);
 void        die(int sig);
 static void signal_init(void);
 static void boot_time_init(void);
@@ -2697,7 +2697,7 @@ static void init(void)
 		 * Good software also always checks its return values...
 		 * If syslogd starts up before DNS is up & /etc/hosts
 		 * doesn't have LocalHostName listed, gethostbyname will
-		 * return NULL. 
+		 * return NULL.
 		 */
 		hent = gethostbyname(LocalHostName);
 		if (hent)


### PR DESCRIPTION
This fixes build errors when using `-std=c2x` flag:
```
syslogd.c:2156:6: error: conflicting types for 'endtty'; have 'void(int)'
 2156 | void endtty(int signo)
      |      ^~~~~~
syslogd.c:204:13: note: previous declaration of 'endtty' with type 'void(void)'
  204 | void        endtty();
      |             ^~~~~~
syslogd.c:2264:6: error: conflicting types for 'reapchild'; have 'void(int)'
 2264 | void reapchild(int signo)
      |      ^~~~~~~~~
syslogd.c:206:13: note: previous declaration of 'reapchild' with type 'void(void)'
  206 | void        reapchild();
      |             ^~~~~~~~~
syslogd.c:2443:6: error: conflicting types for 'debug_switch'; have 'void(int)'
 2443 | void debug_switch(int signo)
      |      ^~~~~~~~~~~~
syslogd.c:212:13: note: previous declaration of 'debug_switch' with type 'void(void)'
  212 | void        debug_switch();
      |             ^~~~~~~~~~~~
```
