### PR TITLE
Fix various typos

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -508,7 +508,7 @@ and a replacement for `syslog.h` to enable new features in RFC5424.
 - New `syslogp()` API from NetBSD, for applications wanting to use
   RFC5424 features like MsgID or structured data
 - Many *incompatible changes* to command line options in `syslogd` and
-  `klogd` for compatiblity with FreeBSD and NetBSD syslogd.  Examples:
+  `klogd` for compatibility with FreeBSD and NetBSD syslogd.  Examples:
   - In syslogd: `-b` and `-c` have been replaced with `-r` for global
     log rotation, `-a` has been replaced with the new `-p` support.  The
     `-r` flag and `-s HOST` has also been dropped in favor of the BSD

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Main differences from the original sysklogd package are:
 
 - The separate `klogd` daemon is no longer part of the sysklogd project,
   syslogd now natively supports logging kernel messages as well
-- *Major* command line changes to `syslogd`, for compatibilty with *BSD
+- *Major* command line changes to `syslogd`, for compatibility with *BSD
 - Supports `include /etc/syslog.d/*.conf` directive, see example .conf
 - Built-in log-rotation support, with compression by default, useful for
   embedded systems.  No need for cron and/or a separate log rotate daemon

--- a/man/syslog.conf.5
+++ b/man/syslog.conf.5
@@ -704,7 +704,7 @@ This example shows one combination of program and hostname filters.
 !-ppp
 *.*                          /var/log/syslog
 
-# Local pppd messages of severity info, or higer, go to its own log file
+# Local pppd messages of severity info, or higher, go to its own log file
 !+ppp
 *.info                       /var/log/ppp.log
 

--- a/src/logger.c
+++ b/src/logger.c
@@ -286,7 +286,7 @@ static int usage(int code)
 	       "  -h HOST   Send (UDP) message to this remote syslog server (IP or DNS name)\n"
 	       "  -H NAME   Use NAME instead of system hostname in message header\n"
 	       "  -i        Log process ID of the logger process with each line (LOG_PID)\n"
-	       "  -I PID    Log process ID using PID, recommed using PID $$ for shell scripts\n"
+	       "  -I PID    Log process ID using PID, recommend using PID $$ for shell scripts\n"
 #ifdef __linux__
 	       "  -k        Log to kernel /dev/kmsg if /dev/log doesn't exist yet\n"
 #endif

--- a/src/syslog.h
+++ b/src/syslog.h
@@ -191,7 +191,7 @@ CODE facilitynames[] = {
 #define	LOG_NDELAY	0x008	/* don't delay open */
 #define	LOG_NOWAIT	0x010	/* don't wait for console forks: DEPRECATED */
 #define	LOG_PERROR	0x020	/* log to stderr as well */
-#define	LOG_PTRIM	0x040	/* trim anything syslog addded when writing to stderr */
+#define	LOG_PTRIM	0x040	/* trim anything syslog added when writing to stderr */
 #define	LOG_NLOG	0x080	/* don't write to the system log */
 #define	LOG_STDOUT	0x100	/* like nlog, for debugging syslogp() API */
 #define	LOG_RFC3164     0x200	/* Log to remote/ipc socket in old BSD format */

--- a/src/syslogd.c
+++ b/src/syslogd.c
@@ -177,7 +177,7 @@ static TAILQ_HEAD(notifiers, notifier) nothead = TAILQ_HEAD_INITIALIZER(nothead)
 static TAILQ_HEAD(peers, peer) pqueue = TAILQ_HEAD_INITIALIZER(pqueue);
 
 /*
- * List fo peers allowed to log to us.
+ * List of peers allowed to log to us.
  */
 static SIMPLEQ_HEAD(allowed, allowedpeer) aphead = SIMPLEQ_HEAD_INITIALIZER(aphead);
 
@@ -4456,7 +4456,7 @@ static void notifier_free_all(void)
 }
 
 /*
- * The following function is resposible for handling a SIGHUP signal.  Since
+ * The following function is responsible for handling a SIGHUP signal.  Since
  * we are now doing mallocs/free as part of init we had better not being
  * doing this during a signal handler.  Instead this function simply sets
  * a flag variable which will tell the main loop to go through a restart.

--- a/src/syslogd.h
+++ b/src/syslogd.h
@@ -224,7 +224,7 @@
 #define F_PIPE            9   /* named pipe */
 
 /*
- * Stuct to hold property-based filters
+ * Struct to hold property-based filters
  */
 struct prop_filter {
 	uint8_t	prop_type;

--- a/syslog.conf
+++ b/syslog.conf
@@ -44,7 +44,7 @@ mail.err			 /var/log/mail.err
 
 #
 # Store all critical events, except kernel logs, in critical RFC5424 format.
-# Overide global log rotation settings, rotate every 10MiB, keep 5 old logs,
+# Override global log rotation settings, rotate every 10MiB, keep 5 old logs,
 #
 #*.=crit;kern.none		/var/log/critical	;rotate=10M:5,RFC5424
 
@@ -68,7 +68,7 @@ mail.err			 /var/log/mail.err
 # Secure mode, same as -s, none(0), on(1), full(2).  When enabled
 # only logging to remote syslog server possible, with full secure
 # mode, not even that is possible.  We default to prevent syslogd
-# from opening UDP/514 and receving messages from other systems.
+# from opening UDP/514 and receiving messages from other systems.
 #
 secure_mode 1
 

--- a/test/listen.sh
+++ b/test/listen.sh
@@ -99,10 +99,10 @@ run_step "Verify listen off - no remote no ports"             verify_secure_daem
 run_step "Verify listen off - only send to remote, no ports"  verify_safe_daemon
 run_step "Verify listen on, default"                          verify_default_daemon
 
-run_step "Verfiy listen on 127.0.0.1:510"                     verify_local_daemon
+run_step "Verify listen on 127.0.0.1:510"                     verify_local_daemon
 run_step "Verify port 514 is closed"                          check_not_open 514
 
-run_step "Verfiy listen on 10.0.0.1:512"                      verify_bind
+run_step "Verify listen on 10.0.0.1:512"                      verify_bind
 run_step "Verify port 510 is closed"                          check_not_open 510
 
 run_step "Verify delayed bind to new address 10.0.0.2:513"    verify_delayed_bind


### PR DESCRIPTION
Fixes user-facing and non-user-facing typos
Found via `codespell -q 3 -L bootup,clen,nd,servent,siz,tast,unx`