### PR TITLE
Add `pri` as an option

### DIFF
--- a/man/syslog.conf.5
+++ b/man/syslog.conf.5
@@ -91,6 +91,7 @@ ACTION   := /path/to/file
 OPTION   := [OPTION,]
 	 |= RFC3164
 	 |= RFC5424
+	 |= pri
 	 |= iface=IFNAME
          |= rotate=ROT
 	 |= ttl=1..255
@@ -204,8 +205,8 @@ specified action.  The
 details where or what to do with the selected input.  The
 .Em option
 field, which must start with the semi-colon option delimiter (';'),
-currently supports log formatting, log rotation, outbound interface and
-TTL when forwarding to a multicast group.
+currently supports priority, log formatting, log rotation, outbound
+interface and TTL when forwarding to a multicast group.
 .Pp
 The default log format is the traditional RFC3164 (included here for
 completeness),
@@ -223,6 +224,22 @@ it is only the default for remote targets for compatibility reasons.
 .Li Aug 24 05:14:15 192.0.2.1 myproc[8710]: Kilroy was here.
 .It Sy RFC5424:
 .Li 2003-08-24T05:14:15.000003-07:00 192.0.2.1 myproc 8710 - - Kilroy was here.
+.El
+.Pp
+By default,
+.Nm sysklogd
+does not print the priority of a message. However, it will if
+.Sy pri
+is added to the options. Printing the priority adds the priority in
+angled brackets to the message header in accordance with the RFC
+standard in use. Below is an example using the user-level facility and a
+warning severity.
+.Pp
+.Bl -tag -compact -width "RFC3164:"
+.It Sy RFC3164:
+.Li <12> Aug 24 05:14:15 192.0.2.1 myproc[8710]: Kilroy was here.
+.It Sy RFC5424:
+.Li <12>1 2003-08-24T05:14:15.000003-07:00 192.0.2.1 myproc 8710 - - Kilroy was here.
 .El
 .Pp
 The log rotation, which is only relevant for files, details the max
@@ -900,6 +917,20 @@ command line option,
 # every 100 kiB and keep up to 10 aged out, and compressed, files.
 #
 *.*;kern.none               -/var/log/messages    ;rotate=100k:10
+.Ed
+.Ss Priority
+The first example logs user messages to the file
+.Pa /var/log/messages
+with syncing and prints the priority for each message. The second
+example logs syslog messages to the file
+.Pa /var/log/syslog
+without syncing and with the rotation from the above example, on top of
+printing the priority for each message.
+.Bd -literal -offset indent
+# Turn on priority printing for each user and syslog message.
+#
+user.*                      /var/log/messages     ;pri
+syslog.*                    -/var/log/syslog      ;rotate=100k:10,pri
 .Ed
 .Ss Logging to Remote Syslog Server
 These rules redirect all messages to remote hosts.  The first is to

--- a/src/syslogd.c
+++ b/src/syslogd.c
@@ -2311,6 +2311,7 @@ void fprintlog_write(struct filed *f, struct iovec *iov, int iovcnt, int flags)
 	ssize_t len = 0;
 	ssize_t lsent;
 	time_t fwd_suspend;
+	int start;
 
 	switch (f->f_type) {
 	case F_UNUSED:
@@ -2448,7 +2449,13 @@ void fprintlog_write(struct filed *f, struct iovec *iov, int iovcnt, int flags)
 		if (f->f_type == F_FILE)
 			logrotate(f);
 
-		if (writev(f->f_file, &iov[1], iovcnt - 1) < 0) {
+		/* This returns 1 if priority is not set, and 0 if it is.
+		   Since the priority is in the first index (0) of the iovec,
+		   this becomes the index of the first item in use, skipping
+		   the priority if the option is off. */
+		start = ((f->f_flags & PRI) == 0);
+
+		if (writev(f->f_file, &iov[start], iovcnt - start) < 0) {
 			int e = errno;
 
 			/* If a named pipe is full, just ignore it for now */
@@ -3555,6 +3562,9 @@ static void cfopts(char *ptr, struct filed *f)
 			if (ttl <= 0 || ttl > 255)
 				ttl = 0;
 			f->f_ttl = ttl;
+		}
+		else if (cfopt(&opt, "pri")) {
+			f->f_flags |= PRI;
 		} else if (cfopt(&opt, "rotate="))
 			cfrot(opt, f);
 		else

--- a/src/syslogd.h
+++ b/src/syslogd.h
@@ -191,6 +191,7 @@
 #define MARK      0x008  /* this message is a mark */
 #define RFC3164   0x010  /* format log message according to RFC 3164 */
 #define RFC5424   0x020  /* format log message according to RFC 5424 */
+#define PRI       0x040  /* always print priority */
 
 /* Syslog timestamp formats. */
 #define	BSDFMT_DATELEN	0


### PR DESCRIPTION
This makes it so `syslogd` always prints the priority.

This is also a personal want of mine. I have no idea if it is something that you might want, however.